### PR TITLE
Add crash logging and fix several bugs

### DIFF
--- a/src/main/scala/com/martomate/hexacraft/game/GameScene.scala
+++ b/src/main/scala/com/martomate/hexacraft/game/GameScene.scala
@@ -56,7 +56,12 @@ class GameScene(saveFolder: File, worldSettings: WorldSettings)(implicit window:
 
   private val worldRenderer: WorldRenderer = new WorldRenderer(world)
 
-  val camera: Camera = new Camera(new CameraProjection(70f, window.aspectRatio, 0.02f, 1000f))
+  val camera: Camera = new Camera(new CameraProjection(70f, window.aspectRatio, 0.02f,
+                                                       world.size.worldSize match {
+                                                         case 0 => 100000f
+                                                         case 1 => 10000f
+                                                         case _ => 1000f
+                                                       }))
   private val mousePicker: RayTracer = new RayTracer(world, camera, 7)
   private val playerInputHandler: PlayerInputHandler = new PlayerInputHandler(window.mouse, window.keyboard, world.player)
 

--- a/src/main/scala/com/martomate/hexacraft/main/Main.scala
+++ b/src/main/scala/com/martomate/hexacraft/main/Main.scala
@@ -1,16 +1,38 @@
 package com.martomate.hexacraft.main
 
-import java.io.File
-
+import java.io.{File, FileOutputStream, PrintStream}
 import com.martomate.hexacraft.util.os.OSUtils
 import org.lwjgl.system.Configuration
+
+import java.time.OffsetDateTime
 
 object Main {
   def main(args: Array[String]): Unit = {
     setNatviesFolder()
 
     val window = new MainWindow
-    window.run()
+    try {
+      window.run()
+    } catch {
+      case t: Throwable =>
+        logThrowable(t, window.saveFolder)
+        System.exit(1);
+    }
+  }
+
+  private def logThrowable(e: Throwable, saveFolder: File): Unit = {
+    val isDebugStr = System.getProperty("hexacraft.debug")
+    val isDebug = isDebugStr != null && isDebugStr == "true"
+
+    if (isDebug) {
+      e.printStackTrace()
+    } else {
+      val now = OffsetDateTime.now()
+      val logFile = new File(saveFolder, s"logs/error_${now}.log")
+      logFile.getParentFile.mkdirs()
+      e.printStackTrace(new PrintStream(new FileOutputStream(logFile)))
+      System.err.println("The program has crashed. The crash report can be found in: " + logFile.getAbsolutePath)
+    }
   }
 
   private def setNatviesFolder(): Unit = {

--- a/src/main/scala/com/martomate/hexacraft/main/VsyncManager.scala
+++ b/src/main/scala/com/martomate/hexacraft/main/VsyncManager.scala
@@ -1,0 +1,31 @@
+package com.martomate.hexacraft.main
+
+class VsyncManager(lo: Int, hi: Int, onUpdate: Boolean => Unit) {
+  private var vsync = false
+  private var consecutiveToggleAttempts = 0
+
+  def isVsync: Boolean = vsync
+
+  def handleVsync(fps: Int): Unit = {
+    val newVsync = shouldUseVsync(fps)
+
+    if (newVsync != vsync) {
+      consecutiveToggleAttempts += 1
+    } else {
+      consecutiveToggleAttempts = 0
+    }
+
+    if (consecutiveToggleAttempts >= 3) {
+      consecutiveToggleAttempts = 0
+      vsync = newVsync
+      onUpdate(vsync)
+    }
+  }
+
+  private def shouldUseVsync(fps: Int): Boolean = {
+    if (fps > hi) true
+    else if (fps < lo) false
+    else vsync
+  }
+
+}

--- a/src/main/scala/com/martomate/hexacraft/util/AsyncFileIO.scala
+++ b/src/main/scala/com/martomate/hexacraft/util/AsyncFileIO.scala
@@ -1,0 +1,36 @@
+package com.martomate.hexacraft.util
+
+import java.io.File
+import java.util.concurrent.Executors
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
+
+object AsyncFileIO {
+  private implicit val executionContext: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(16))
+
+  private val lockedFiles: mutable.Set[String] = mutable.Set.empty
+
+  def submit[T](file: File, job: File => T): Future[T] = Future {
+    val realPath = file.getCanonicalPath
+
+    lockedFiles.synchronized {
+      while (lockedFiles.contains(realPath))
+        lockedFiles.wait()
+
+      lockedFiles += realPath
+    }
+    try {
+      job(file)
+    } finally {
+      lockedFiles.synchronized {
+        lockedFiles -= realPath
+        lockedFiles.notifyAll()
+      }
+    }
+  }
+
+  def unload(): Unit = {
+    executionContext.shutdown()
+  }
+}

--- a/src/main/scala/com/martomate/hexacraft/util/MathUtils.scala
+++ b/src/main/scala/com/martomate/hexacraft/util/MathUtils.scala
@@ -9,4 +9,9 @@ object MathUtils {
       zz
     }
   }
+
+  /** @return x or (x - C) depending on which one is closest to 0 on the modulo circle */
+  def absmin(x: Double, circumference: Double): Double = {
+    fitZ(x + circumference / 2, circumference) - circumference / 2
+  }
 }

--- a/src/main/scala/com/martomate/hexacraft/world/camera/Camera.scala
+++ b/src/main/scala/com/martomate/hexacraft/world/camera/Camera.scala
@@ -79,6 +79,6 @@ class Camera(val proj: CameraProjection)(implicit val worldSize: CylinderSize) {
     val x = ((position.x - camX) / mult + camX) / 0.75
     val z = position.z / CylinderSize.y60 - x / 2
 
-    CoordUtils.toBlockCoords(BlockCoords(x, y, z))
+    CoordUtils.getEnclosingBlock(BlockCoords(x, y, z))
   }
 }

--- a/src/main/scala/com/martomate/hexacraft/world/coord/CoordUtils.scala
+++ b/src/main/scala/com/martomate/hexacraft/world/coord/CoordUtils.scala
@@ -8,7 +8,7 @@ import org.joml.Vector3d
 import scala.annotation.tailrec
 
 object CoordUtils {
-  def toBlockCoords(vec: BlockCoords): (BlockRelWorld, BlockCoords) = {
+  def getEnclosingBlock(vec: BlockCoords): (BlockRelWorld, BlockCoords) = {
     import vec.cylSize.impl
 
     val (x, y, z) = (vec.x, vec.y, vec.z)

--- a/src/main/scala/com/martomate/hexacraft/world/coord/fp/BlockCoords.scala
+++ b/src/main/scala/com/martomate/hexacraft/world/coord/fp/BlockCoords.scala
@@ -12,6 +12,7 @@ class BlockCoords private (_x: Double, _y: Double, _z: Double, fixZ: Boolean)(im
   def toSkewCylCoords: SkewCylCoords = SkewCylCoords(x * CylinderSize.y60, y * 0.5, z * CylinderSize.y60, fixZ)
 
   override def offset(dx: Double, dy: Double, dz: Double): BlockCoords = BlockCoords(x + dx, y + dy, z + dz, fixZ)
+  def offset(c: BlockCoords): BlockCoords = this + c
 }
 
 /** BlockCoords are like SkewCylCoords but with a different axis scale */

--- a/src/main/scala/com/martomate/hexacraft/world/coord/fp/CylCoords.scala
+++ b/src/main/scala/com/martomate/hexacraft/world/coord/fp/CylCoords.scala
@@ -41,6 +41,7 @@ class CylCoords private (_x: Double, _y: Double, _z: Double, fixZ: Boolean)(impl
   }
 
   override def offset(dx: Double, dy: Double, dz: Double): CylCoords = CylCoords(x + dx, y + dy, z + dz, fixZ)
+  def offset(v: Vector3d): CylCoords = offset(v.x, v.y, v.z)
 }
 
 /** NormalCoords with z axis wrapped around a cylinder. The y axis is perpendicular to the x and z axes and also exponential */

--- a/src/main/scala/com/martomate/hexacraft/world/entity/player/ai/SimplePlayerAIInput.scala
+++ b/src/main/scala/com/martomate/hexacraft/world/entity/player/ai/SimplePlayerAIInput.scala
@@ -14,5 +14,5 @@ class SimplePlayerAIInput(world: IWorld, player: PlayerEntity) extends EntityAII
   def blockInFront(dist: Double): Block = world.getBlock(coordsAtOffset(dist * math.cos(player.rotation.y), 0, dist * -math.sin(player.rotation.y))).blockType
 
   private def coordsAtOffset(dx: Double, dy: Double, dz: Double): BlockRelWorld =
-    CoordUtils.toBlockCoords(CylCoords(player.position.x + dx, player.position.y + dy, player.position.z + dz).toBlockCoords)._1
+    CoordUtils.getEnclosingBlock(CylCoords(player.position.x + dx, player.position.y + dy, player.position.z + dz).toBlockCoords)._1
 }

--- a/src/main/scala/com/martomate/hexacraft/world/entity/sheep/ai/SimpleSheepAIInput.scala
+++ b/src/main/scala/com/martomate/hexacraft/world/entity/sheep/ai/SimpleSheepAIInput.scala
@@ -14,5 +14,5 @@ class SimpleSheepAIInput(world: IWorld, sheep: SheepEntity) extends EntityAIInpu
   def blockInFront(dist: Double): Block = world.getBlock(coordsAtOffset(dist * math.cos(sheep.rotation.y), 0, dist * -math.sin(sheep.rotation.y))).blockType
 
   private def coordsAtOffset(dx: Double, dy: Double, dz: Double): BlockRelWorld =
-    CoordUtils.toBlockCoords(CylCoords(sheep.position.x + dx, sheep.position.y + dy, sheep.position.z + dz).toBlockCoords)._1
+    CoordUtils.getEnclosingBlock(CylCoords(sheep.position.x + dx, sheep.position.y + dy, sheep.position.z + dz).toBlockCoords)._1
 }

--- a/src/main/scala/com/martomate/hexacraft/world/render/ChunkRendererImpl.scala
+++ b/src/main/scala/com/martomate/hexacraft/world/render/ChunkRendererImpl.scala
@@ -139,7 +139,7 @@ class ChunkRendererImpl(chunk: IChunk, world: IWorld) extends ChunkRenderer {
         val parts = for (part <- model.parts) yield {
           baseT.mul(part.transform, tr)
           val coords4 = tr.transform(new Vector4f(0, 0.5f, 0, 1))
-          val coords = CoordUtils.toBlockCoords(CylCoords(coords4.x, coords4.y, coords4.z).toBlockCoords)._1
+          val coords = CoordUtils.getEnclosingBlock(CylCoords(coords4.x, coords4.y, coords4.z).toBlockCoords)._1
           val cCoords = coords.getChunkRelWorld
           val partChunk = if (cCoords == chunk.coords) Some(chunk) else world.getChunk(cCoords)
           val brightness: Float = partChunk.map(_.lighting.getBrightness(coords.getBlockRelChunk)).getOrElse(0)


### PR DESCRIPTION
- If the game crashes the error log will now be saved in a log file in the `.hexacraft/logs` folder.
- Previously vsync was disabled if the fps dropped below 50 and enabled if it reached over 80. Now this has to be true for 3 seconds before it is toggled.
- There is a new class `AsyncFileIO` to be used for reading and writing files. Previously a read and a write to the same file could be performed simultaneously resulting in a crash, but now that is no longer possible.
- When moving close to z=0 the collision detection didn't work properly, but now it does.
- In two places there was a risk of infinite recursion resulting in the occational StackOverflowError. This has now been temporarily fixed by limiting the recursion depth. The underlying bugs remain, but at least the game doesn't crash anymore.