### PR TITLE
Fix infamous window resizing bug

### DIFF
--- a/game/src/test/scala/hexacraft/game/FakeGameKeyboard.scala
+++ b/game/src/test/scala/hexacraft/game/FakeGameKeyboard.scala
@@ -1,0 +1,11 @@
+package hexacraft.game
+
+import scala.collection.mutable
+
+class FakeGameKeyboard(override val pressedKeys: Seq[GameKeyboard.Key]) extends GameKeyboard {
+  override def keyIsPressed(key: GameKeyboard.Key) = {
+    pressedKeys.contains(key)
+  }
+
+  override def refreshPressedKeys(): Unit = ()
+}

--- a/game/src/test/scala/hexacraft/game/PlayerInputHandlerTest.scala
+++ b/game/src/test/scala/hexacraft/game/PlayerInputHandlerTest.scala
@@ -7,27 +7,32 @@ import munit.FunSuite
 import org.joml.Vector2f
 
 import java.util.UUID
-import scala.collection.mutable
 
 class PlayerInputHandlerTest extends FunSuite {
   given CylinderSize = CylinderSize(8)
 
-  test("tick should ask the keyboard for pressed keys") {
-    import GameKeyboard.Key
-    val keyboardCalls = mutable.Set.empty[GameKeyboard.Key]
-    val keyboard: GameKeyboard = key =>
-      keyboardCalls += key
-      key == Key.MoveForward
+  test("tick should update the velocity if MoveForward is pressed") {
+    val keyboard = FakeGameKeyboard(Seq(GameKeyboard.Key.MoveForward))
     val player = Player.atStartPos(UUID.randomUUID(), CylCoords(1.23, 2.45, 3.56))
     val handler = new PlayerInputHandler()
 
+    assert(player.velocity.length() == 0)
     handler.tick(player, keyboard.pressedKeys, new Vector2f, 1.0, false)
+    assert(player.velocity.length() > 0)
+  }
 
-    assert(keyboardCalls.toSet.contains(Key.MoveForward))
+  test("tick should not update the velocity if no key is pressed") {
+    val keyboard = FakeGameKeyboard(Seq.empty)
+    val player = Player.atStartPos(UUID.randomUUID(), CylCoords(1.23, 2.45, 3.56))
+    val handler = new PlayerInputHandler()
+
+    assert(player.velocity.length() == 0)
+    handler.tick(player, keyboard.pressedKeys, new Vector2f, 1.0, false)
+    assert(player.velocity.length() == 0)
   }
 
   test("tick should not rotate the player if mouse has not moved") {
-    val keyboard: GameKeyboard = _ => false
+    val keyboard = FakeGameKeyboard(Seq.empty)
     val player = Player.atStartPos(UUID.randomUUID(), CylCoords(1.23, 2.45, 3.56))
     val handler = new PlayerInputHandler()
 
@@ -40,7 +45,7 @@ class PlayerInputHandlerTest extends FunSuite {
   }
 
   test("test should rotate the player if mouse has moved") {
-    val keyboard: GameKeyboard = _ => false
+    val keyboard = FakeGameKeyboard(Seq.empty)
     val player = Player.atStartPos(UUID.randomUUID(), CylCoords(1.23, 2.45, 3.56))
     val handler = new PlayerInputHandler()
 

--- a/gpu/src/main/scala/hexacraft/infra/gpu/OpenGL.scala
+++ b/gpu/src/main/scala/hexacraft/infra/gpu/OpenGL.scala
@@ -629,6 +629,14 @@ object OpenGL {
       def |(r: ClearMask): ClearMask = l | r
   }
 
+  def lockContext(): Unit = {
+    gl.lockContext()
+  }
+
+  def unlockContext(): Unit = {
+    gl.unlockContext()
+  }
+
   def glIsEnabled(target: State): Boolean = {
     gl.glIsEnabled(target.toGL)
   }
@@ -794,6 +802,9 @@ trait GLWrapper {
   def createCapabilities(): GLCapabilitiesWrapper
   def getCapabilities: GLCapabilitiesWrapper
 
+  def lockContext(): Unit
+  def unlockContext(): Unit
+
   def glCreateShader(shaderType: Int): Int
   def glShaderSource(shader: Int, string: String): Unit
   def glCompileShader(shader: Int): Unit
@@ -908,6 +919,9 @@ trait GLWrapper {
 class StubGL extends GLWrapper {
   def createCapabilities(): GLCapabilitiesWrapper = new StubGLCapabilities
   def getCapabilities: GLCapabilitiesWrapper = new StubGLCapabilities
+
+  def lockContext(): Unit = ()
+  def unlockContext(): Unit = ()
 
   private var lastShaderId = 8
   def glCreateShader(shaderType: Int): Int =
@@ -1044,6 +1058,9 @@ class StubGL extends GLWrapper {
 object RealGL extends GLWrapper {
   def createCapabilities(): GLCapabilitiesWrapper = new RealGLCapabilities(GL.createCapabilities())
   def getCapabilities: GLCapabilitiesWrapper = new RealGLCapabilities(GL.getCapabilities)
+
+  def lockContext(): Unit = CGL.CGLLockContext(CGL.CGLGetCurrentContext())
+  def unlockContext(): Unit = CGL.CGLUnlockContext(CGL.CGLGetCurrentContext())
 
   def glCreateShader(shaderType: Int): Int = GL20.glCreateShader(shaderType)
   def glShaderSource(shader: Int, string: String): Unit = GL20.glShaderSource(shader, string)

--- a/main/src/main/scala/hexacraft/main/Application.scala
+++ b/main/src/main/scala/hexacraft/main/Application.scala
@@ -19,13 +19,25 @@ class Application(
     val saveFolder: File = this.createSaveFolder()
 
     try {
-      val window = new MainWindow(config.isDebug, saveFolder, fs, audioSystem, windowSystem)
+      var gameIsRunning = true
 
-      if config.isDebug then {
-        this.performShortcuts(saveFolder, window)
+      val gameThread = new Thread(() => {
+        val window = new MainWindow(config.isDebug, saveFolder, fs, audioSystem, windowSystem)
+
+        if config.isDebug then {
+          this.performShortcuts(saveFolder, window)
+        }
+
+        window.run()
+
+        gameIsRunning = false
+      })
+      gameThread.start()
+
+      while gameIsRunning do {
+        windowSystem.performCallsAsMainThread()
+        Thread.sleep(1)
       }
-
-      window.run()
 
       true
     } catch {

--- a/main/src/test/scala/hexacraft/main/GameSceneTest.scala
+++ b/main/src/test/scala/hexacraft/main/GameSceneTest.scala
@@ -1,7 +1,7 @@
 package hexacraft.main
 
 import hexacraft.client.FakeBlockTextureLoader
-import hexacraft.game.GameKeyboard
+import hexacraft.game.{FakeGameKeyboard, GameKeyboard}
 import hexacraft.gui.{Event, MousePosition, TickContext, WindowSize}
 import hexacraft.gui.Event.{KeyEvent, MouseClickEvent}
 import hexacraft.infra.audio.AudioSystem
@@ -38,7 +38,7 @@ class GameSceneTest extends FunSuite {
     val textureLoader = new FakeBlockTextureLoader
 
     // Load and unload the game (to ensure static shaders are loaded)
-    val keyboard: GameKeyboard = _ => false
+    val keyboard = FakeGameKeyboard(Seq.empty)
     val audioSystem = AudioSystem.createNull()
 
     val (gameScene1, _) =
@@ -90,7 +90,7 @@ class GameSceneTest extends FunSuite {
     OpenGL._enterTestMode()
 
     val worldProvider = new FakeWorldProvider(123L)
-    val keyboard: GameKeyboard = _ => false
+    val keyboard = FakeGameKeyboard(Seq.empty)
     val textureLoader = new FakeBlockTextureLoader
     val audioSystem = AudioSystem.createNull()
 
@@ -140,7 +140,7 @@ class GameSceneTest extends FunSuite {
 
     // Step 2: configure the client
 
-    val keyboard: GameKeyboard = _ => false
+    val keyboard = FakeGameKeyboard(Seq.empty)
     val textureLoader = new FakeBlockTextureLoader
     val audioSystem = AudioSystem.createNull()
 
@@ -203,7 +203,7 @@ class GameSceneTest extends FunSuite {
 
     // Step 2: configure the client
 
-    val keyboard: GameKeyboard = _ => false
+    val keyboard = FakeGameKeyboard(Seq.empty)
     val textureLoader = new FakeBlockTextureLoader
     val audioSystem = AudioSystem.createNull()
 

--- a/window/src/main/scala/hexacraft/infra/window/CallbackEvent.scala
+++ b/window/src/main/scala/hexacraft/infra/window/CallbackEvent.scala
@@ -4,6 +4,7 @@ enum CallbackEvent {
   case KeyPressed(window: Window, key: KeyboardKey, scancode: Int, action: KeyAction, mods: KeyMods)
   case CharTyped(window: Window, character: Int)
   case MouseClicked(window: Window, button: MouseButton, action: MouseAction, mods: KeyMods)
+  case MousePosition(window: Window, x: Double, y: Double)
   case MouseScrolled(window: Window, xOffset: Double, yOffset: Double)
   case WindowResized(window: Window, w: Int, h: Int)
   case WindowFocusChanged(window: Window, focused: Boolean)

--- a/window/src/main/scala/hexacraft/infra/window/Monitor.scala
+++ b/window/src/main/scala/hexacraft/infra/window/Monitor.scala
@@ -5,7 +5,7 @@ import hexacraft.util.PointerWrapper
 class Monitor(val id: Monitor.Id, glfw: GlfwWrapper) {
   private val pointerWrapper = new PointerWrapper()
 
-  def position: (Int, Int) = {
+  def position: (Int, Int) = pointerWrapper.synchronized {
     pointerWrapper.ints((px, py) => glfw.glfwGetMonitorPos(id.toLong, px, py))
   }
 

--- a/window/src/main/scala/hexacraft/infra/window/Window.scala
+++ b/window/src/main/scala/hexacraft/infra/window/Window.scala
@@ -15,13 +15,21 @@ object Window {
 class Window(val id: Window.Id, glfw: GlfwWrapper) {
   private val pointerWrapper = new PointerWrapper()
 
-  def position: (Int, Int) = pointerWrapper.ints((px, py) => glfw.glfwGetWindowPos(id.toLong, px, py))
+  def position: (Int, Int) = pointerWrapper.synchronized {
+    pointerWrapper.ints((px, py) => glfw.glfwGetWindowPos(id.toLong, px, py))
+  }
 
-  def size: (Int, Int) = pointerWrapper.ints((px, py) => glfw.glfwGetWindowSize(id.toLong, px, py))
+  def size: (Int, Int) = pointerWrapper.synchronized {
+    pointerWrapper.ints((px, py) => glfw.glfwGetWindowSize(id.toLong, px, py))
+  }
 
-  def framebufferSize: (Int, Int) = pointerWrapper.ints((px, py) => glfw.glfwGetFramebufferSize(id.toLong, px, py))
+  def framebufferSize: (Int, Int) = pointerWrapper.synchronized {
+    pointerWrapper.ints((px, py) => glfw.glfwGetFramebufferSize(id.toLong, px, py))
+  }
 
-  def cursorPosition: (Double, Double) = pointerWrapper.doubles((px, py) => glfw.glfwGetCursorPos(id.toLong, px, py))
+  def cursorPosition: (Double, Double) = pointerWrapper.synchronized {
+    pointerWrapper.doubles((px, py) => glfw.glfwGetCursorPos(id.toLong, px, py))
+  }
 
   def shouldClose: Boolean = glfw.glfwWindowShouldClose(id.toLong)
 
@@ -92,6 +100,13 @@ class Window(val id: Window.Id, glfw: GlfwWrapper) {
             KeyMods.fromGlfw(mods)
           )
         )
+    )
+  }
+
+  def setCursorPosCallback(callback: CallbackEvent.MousePosition => Unit): Unit = {
+    glfw.glfwSetCursorPosCallback(
+      id.toLong,
+      (_, x, y) => callback(CallbackEvent.MousePosition(this, x, y))
     )
   }
 


### PR DESCRIPTION
This commit fixes a bug on Mac where the game loop hangs during window resize. This could cause the player to be kicked from the server due to inactivity (no packets sent in over a second) and it also causes the UI to freeze and stretch. The network issue could be solved with ping packets, but I wanted to solve the underlying problem instead, so here we go:

To fix these issues the main application thread was split in two:
1. The main thread only runs code that has to be run on the main thread (mostly window management code).
2. The game thread runs the game loop (which was previously run by the main thread) but can ask the main thread to perform tasks if needed. It then waits for the main thread to run it, except in some cases where the call has been wrapped in a Future in order to not block the game loop.

The reason for all of this back-and-forth is that most functions in GLFW (window manager) have to be run on the main thread and all functions in OpenGL have to be run on only one thread (the game thread in this case).

In addition to all of this Apple has also decided that one has to lock the OpenGL context before using it, and if you don't you will get various memory corruption issues in the native code and the game will likely crash. Luckily this was quite easy to fix.

At the end of all of this, it actually works pretty well!