### PR TITLE
Add jlink packaging to remove dependency on pre-existing Java installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  package:
+    name: Build and package release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            name: linux-x64
+          - os: ubuntu-24.04-arm
+            name: linux-arm64
+          - os: macos-13
+            name: macos-x64
+          - os: macos-14
+            name: macos-arm64
+          - os: windows-2022
+            name: windows-x64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Setup
+        uses: coursier/setup-action@v1
+        with:
+          jvm: "adoptium:1.17"
+
+      - name: Build and package
+        run: ./mill main.universalStagePackageZip
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: hexacraft-${{matrix.name}}
+          path: ./out/main/universalStagePackageZip.dest/

--- a/build.mill
+++ b/build.mill
@@ -116,6 +116,44 @@ object main extends HexacraftModule with JavaAppPackagingModule {
     Seq(Deps.Joml, Deps.ZeroMQ) ++ Deps.LwjglSystem: _*
   )
 
+  def jdepsModules: T[String] = Task {
+    val classPath = runClasspath().map(_.path).filter(os.exists).map(_.toString)
+    val res = os.proc(
+      Seq(
+        Jvm.jdkTool("jdeps", this.zincWorker().javaHome().map(_.path)),
+        "--multi-release", "17",
+        "-R",
+        "--print-module-deps",
+        "--ignore-missing-deps",
+        "--class-path",
+      ) ++
+      classPath,
+    ).call()
+
+    new String(res.out.bytes).stripSuffix("\n")
+  }
+
+  def jlinkAppImage: T[PathRef] = Task {
+    val modules = jdepsModules()
+    val outputPath = Task.dest / "runtime"
+
+    val args = Seq(
+      Jvm.jdkTool("jlink", this.zincWorker().javaHome().map(_.path)),
+      "--add-modules",
+      modules,
+      "--output",
+      outputPath.toString,
+      "--compress",
+      "2",
+      "--no-header-files",
+      "--no-man-pages",
+      "--strip-debug"
+    )
+    os.proc(args).call()
+
+    PathRef(outputPath)
+  }
+
   override def forkArgs = super.forkArgs() ++ (if (isMac) Some("-XstartOnFirstThread") else None).toSeq
 
   override def packageVersion = "0.14.1"
@@ -135,8 +173,9 @@ object main extends HexacraftModule with JavaAppPackagingModule {
   override def universalMappings = T {
     val launcherJarPath = launcherJar().path
     val launcherJarMapping = PathRef(launcherJarPath) -> (os.sub / "hexacraft-launcher.jar")
+    val jreMapping = jlinkAppImage() -> (os.sub / "runtime")
 
-    super.universalMappings().filterNot(_._2.startsWith(os.sub / "bin")) ++ Seq(launcherJarMapping)
+    super.universalMappings().filterNot(_._2.startsWith(os.sub / "bin")) ++ Seq(launcherJarMapping, jreMapping)
   }
 
   object test extends Tests {


### PR DESCRIPTION
This will make it possible to download the game and then run it without having to install Java first (which is not a reasonable thing to expect people to do these days).