### PR TITLE
Fix keyboard polling deadlock and JNI handle memory safety issues

### DIFF
--- a/game/src/main/scala/hexacraft/game/GameKeyboard.scala
+++ b/game/src/main/scala/hexacraft/game/GameKeyboard.scala
@@ -39,7 +39,6 @@ object GameKeyboard {
 
   class GlfwKeyboard(window: Window) extends GameKeyboard {
     private var currentlyPressedKeys: Set[GameKeyboard.Key] = Set.empty
-    private var loadingPressedKeys: Boolean = false
 
     def pressedKeys: Seq[GameKeyboard.Key] = {
       currentlyPressedKeys.toSeq
@@ -50,31 +49,25 @@ object GameKeyboard {
     }
 
     def refreshPressedKeys(): Unit = {
-      if !loadingPressedKeys then {
-        loadingPressedKeys = true
-        Future {
-          val pressedPerKey = Seq(
-            (Key.MoveForward, window.isKeyPressed(KeyboardKey.Letter('W'))),
-            (Key.MoveBackward, window.isKeyPressed(KeyboardKey.Letter('S'))),
-            (Key.MoveRight, window.isKeyPressed(KeyboardKey.Letter('D'))),
-            (Key.MoveLeft, window.isKeyPressed(KeyboardKey.Letter('A'))),
-            (Key.Jump, window.isKeyPressed(KeyboardKey.Space)),
-            (Key.Sneak, window.isKeyPressed(KeyboardKey.LeftShift)),
-            (Key.LookUp, window.isKeyPressed(KeyboardKey.Up)),
-            (Key.LookDown, window.isKeyPressed(KeyboardKey.Down)),
-            (Key.LookLeft, window.isKeyPressed(KeyboardKey.Left)),
-            (Key.LookRight, window.isKeyPressed(KeyboardKey.Right)),
-            (Key.TurnHeadLeft, window.isKeyPressed(KeyboardKey.PageUp)),
-            (Key.TurnHeadRight, window.isKeyPressed(KeyboardKey.PageDown)),
-            (Key.MoveSlowly, window.isKeyPressed(KeyboardKey.LeftControl)),
-            (Key.MoveFast, window.isKeyPressed(KeyboardKey.LeftAlt)),
-            (Key.MoveSuperFast, window.isKeyPressed(KeyboardKey.RightControl)),
-            (Key.ResetRotation, window.isKeyPressed(KeyboardKey.Delete) && window.isKeyPressed(KeyboardKey.Letter('R')))
-          )
-          currentlyPressedKeys = pressedPerKey.filter(_._2).map(_._1).toSet
-          loadingPressedKeys = false
-        }
-      }
+      val pressedPerKey = Seq(
+        (Key.MoveForward, window.isKeyPressed(KeyboardKey.Letter('W'))),
+        (Key.MoveBackward, window.isKeyPressed(KeyboardKey.Letter('S'))),
+        (Key.MoveRight, window.isKeyPressed(KeyboardKey.Letter('D'))),
+        (Key.MoveLeft, window.isKeyPressed(KeyboardKey.Letter('A'))),
+        (Key.Jump, window.isKeyPressed(KeyboardKey.Space)),
+        (Key.Sneak, window.isKeyPressed(KeyboardKey.LeftShift)),
+        (Key.LookUp, window.isKeyPressed(KeyboardKey.Up)),
+        (Key.LookDown, window.isKeyPressed(KeyboardKey.Down)),
+        (Key.LookLeft, window.isKeyPressed(KeyboardKey.Left)),
+        (Key.LookRight, window.isKeyPressed(KeyboardKey.Right)),
+        (Key.TurnHeadLeft, window.isKeyPressed(KeyboardKey.PageUp)),
+        (Key.TurnHeadRight, window.isKeyPressed(KeyboardKey.PageDown)),
+        (Key.MoveSlowly, window.isKeyPressed(KeyboardKey.LeftControl)),
+        (Key.MoveFast, window.isKeyPressed(KeyboardKey.LeftAlt)),
+        (Key.MoveSuperFast, window.isKeyPressed(KeyboardKey.RightControl)),
+        (Key.ResetRotation, window.isKeyPressed(KeyboardKey.Delete) && window.isKeyPressed(KeyboardKey.Letter('R')))
+      )
+      currentlyPressedKeys = pressedPerKey.filter(_._2).map(_._1).toSet
     }
   }
 }

--- a/native/src/native/crates/jni/src/handle.rs
+++ b/native/src/native/crates/jni/src/handle.rs
@@ -44,10 +44,8 @@ impl<S: 'static> Handle<S> {
             println!("Using handle: {}", self.raw);
         }
         assert_handle_type::<S>(HANDLES.lock().unwrap().get(&self.raw));
-        let state: Box<S> = unsafe { Box::from_raw(self.raw as *mut S) };
-        let res = f(&state);
-        std::mem::forget(state);
-        res
+        let state: &S = unsafe { &*(self.raw as *const S) };
+        f(state)
     }
 
     pub fn use_handles<R>(handles: &[Handle<S>], f: impl FnOnce(&[&S]) -> R) -> R {
@@ -60,14 +58,11 @@ impl<S: 'static> Handle<S> {
         for h in handles {
             assert_handle_type::<S>(HANDLES.lock().unwrap().get(&h.raw));
         }
-        let state: Vec<Box<S>> = handles
+        let state_refs: Vec<&S> = handles
             .iter()
-            .map(|handle| unsafe { Box::from_raw(handle.raw as *mut S) })
+            .map(|handle| unsafe { &*(handle.raw as *const S) })
             .collect();
-        let state_refs: Vec<&S> = state.iter().map(|s| s.as_ref()).collect();
-        let res = f(&state_refs);
-        std::mem::forget(state);
-        res
+        f(&state_refs)
     }
 
     /// Drops the data and invalidates the handle


### PR DESCRIPTION
1. Synchronized `GlfwKeyboard.refreshPressedKeys` on the execution thread to avoid background thread pool exhaustion and deadlocks caused by blocking `Future` closures waiting on main-thread GLFW callbacks.
2. Refactored Rust JNI `Handle` borrowing to directly dereference raw pointers instead of constructing `Box<S>` instances and calling `mem::forget`. This prevents memory leaks and use-after-free bugs when panics occur during handle inspection.